### PR TITLE
add dutton park

### DIFF
--- a/src/app/calendar/calendar.ts
+++ b/src/app/calendar/calendar.ts
@@ -47,6 +47,10 @@ export const CAMPUSES: Campus[] = [
     name: "Herston",
     code: "HERST",
   },
+  {
+    name: "Dutton Park",
+    code: "DUTPK",
+  },
 ];
 
 export type DeliveryModeId = "IN" | "EX" | "FD" | "WE";


### PR DESCRIPTION
UQ have renamed PACE to Dutton Park, and it seems like updated the timetable with a new DUTPK campus code for those courses that take place there (e.g. PHRM2101)